### PR TITLE
Update smbase/array.h

### DIFF
--- a/smbase/array.h
+++ b/smbase/array.h
@@ -258,7 +258,7 @@ public:
   T      & operator[] (int i)       { return GrowArray<T>::operator[](i); }
 
   void push(T const &val)
-    { setIndexDoubler(len++, val); }
+    { this->setIndexDoubler(len++, val); }
   T pop()
     { return operator[](--len); }
   T const &top() const


### PR DESCRIPTION
Fixes compilation with gcc 4.7

array.h: In instantiation of ‘void ArrayStack<T>::push(const T&) [with T = BPBox_]’:
array.h:372:32:   required from ‘void ObjArrayStack<T>::push(T_) [with T = BPBox]’
boxprint.cc:371:39:   required from here
array.h:261:7: error: ‘setIndexDoubler’ was not declared in this scope, and no declarations were found by argument-dependent lookup at the point of instantiation [-fpermissive]
array.h:261:7: note: declarations in dependent base ‘GrowArray<BPBox*>’ are not found by unqualified lookup
array.h:261:7: note: use ‘this->setIndexDoubler’ instead
