### PR TITLE
Update to elkhound/Makefile.in

### DIFF
--- a/elkhound/Makefile.in
+++ b/elkhound/Makefile.in
@@ -153,11 +153,11 @@ support-set := \
 %.tab.c %.tab.o %.tab.h: %.y
 	bison -d -v $*.y
 	mv $*.tab.c $*.tab.c.orig
-	sed -e 's/YYSTYPE yyval;/YYSTYPE yyval = 0;/' \
+	sed -e 's/YYSTYPE yyval;/YYSTYPE yyval = {0};/' \
 	    -e 's/__attribute__ ((__unused__))//' \
 	  <$*.tab.c.orig >$*.tab.c
 	rm $*.tab.c.orig
-	$(CXX) -c -g -o $*.tab.o -O2 -DNDEBUG -Wall $(YYDEBUG) $*.tab.c
+	$(CXX) -c -g -o $*.tab.o $(CCFLAGS) -O2 -DNDEBUG -Wall $(YYDEBUG) $*.tab.c
 
 # run the trivial-grammar helper
 .PRECIOUS: %.gr %.tree.gr


### PR DESCRIPTION
This fixes compilation issues under Linux. To be more specific, the call to gcc for the Bison-generated files was missing the include of the smbase and ast paths, whose header files are required.

There was also an issue with the initialiser for yyval, I have changed that line so that the initialiser is now (I think) safe for union types.
