### PR TITLE
Update configure script

### DIFF
--- a/configure.pl
+++ b/configure.pl
@@ -106,7 +106,7 @@ sub translate_modes_to_flags {
 sub configure_dir {
     my ($repo, $flags_list_ref) = @_;
     my @flags = @{$flags_list_ref};
-    if (defined @{$subdir2extraargs{$repo}}) {
+    if (defined $subdir2extraargs{$repo} && @{$subdir2extraargs{$repo}}) {
         @flags = (@flags, @{$subdir2extraargs{$repo}});
     }
     my $fulldir = "$stackdir/$repo";


### PR DESCRIPTION
This commit fixes #12.

Perl starting with 5.16 or so stopped supporting "defined (@foo)".
Because in this case the array name can be undefined, we need to check
the name and the validity of the array expression as a whole.