### PR TITLE
Update pages.c to fix issue #15.

### DIFF
--- a/libregion/pages.c
+++ b/libregion/pages.c
@@ -71,6 +71,8 @@ struct page *single_pages;
 /* free pages (not including those in single_pages) */
 struct page *unused_pages;
 
+static void set_region_range(void *from, void *to, region r);
+
 static void init_pages(void)
 {
   pages_byaddress.next_address = &pages_byaddress;


### PR DESCRIPTION
Fixed issue #15. Added forward declaration of set_region_range() to remove compiler warning.