### PR TITLE
Update locstr.h to fix issue #18.

### DIFF
--- a/ast/locstr.h
+++ b/ast/locstr.h
@@ -38,9 +38,9 @@ public:    // funcs
 
   // (read-only) string-like behavior
   friend std::ostream& operator<< (std::ostream &os, LocString const &loc)
-    { return os << loc.str; }
-  friend stringBuilder& operator<< (stringBuilder &sb, LocString const &loc)
-    { return sb << loc.str; }
+    { return os << (loc.isNonNull() ? loc.str : "NULL"); }
+ friend stringBuilder& operator<< (stringBuilder &sb, LocString const &loc)
+    { return sb << (loc.isNonNull() ? loc.str : "NULL"); }
   StringRef strref() const { return str; }
   operator StringRef () const { return str; }
   char operator [] (int index) const { return str[index]; }


### PR DESCRIPTION
Fix for issue #18. As per the comments in locstr.h the str field is permitted to be NULL. This fix protects against NULL pointer dereference in the << operators. This allows elkhound/elkhound elkhound/examples/crash1.gr to pass (not segfault) on Mac OS X.